### PR TITLE
Add custom config file path support via -c flag

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use toml;
 
 use dirs;
 use serde::Deserialize;
+use std::path::PathBuf;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
@@ -132,11 +133,15 @@ impl KeyBindings {
 }
 
 impl Config {
-    pub fn load() -> Self {
-        let conf_path = dirs::config_dir()
-            .unwrap()
-            .join("tenere")
-            .join("config.toml");
+    pub fn load(custom_path: Option<PathBuf>) -> Self {
+        let conf_path = if let Some(path) = custom_path {
+            path
+        } else {
+            dirs::config_dir()
+                .unwrap()
+                .join("tenere")
+                .join("config.toml")
+        };
 
         let config = std::fs::read_to_string(conf_path).unwrap_or_default();
         let app_config: Config = toml::from_str(&config).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
-use std::{env, io};
+use std::{env, io, path::PathBuf};
 use tenere::app::{App, AppResult};
 use tenere::config::Config;
 use tenere::event::{Event, EventHandler};
@@ -14,16 +14,24 @@ use tenere::llm::LLMModel;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use clap::{crate_description, crate_version, Command};
+use clap::{crate_description, crate_version, Command, Arg};
 
 #[tokio::main]
 async fn main() -> AppResult<()> {
-    Command::new("tenere")
+    let matches = Command::new("tenere")
         .about(crate_description!())
         .version(crate_version!())
+        .arg(
+            Arg::new("config")
+            .short('c')
+            .long("config")
+            .help("Path to custom config file")
+            .value_name("FILE")
+        )
         .get_matches();
 
-    let config = Arc::new(Config::load());
+    let config_path = matches.get_one::<String>("config").map(PathBuf::from);
+    let config = Arc::new(Config::load(config_path));
 
     let (formatter_config, formatter_assets) = Formatter::init();
     let formatter = Formatter::new(&formatter_config, &formatter_assets);


### PR DESCRIPTION
## Optionally specify custom path to config.toml

Add ability to specify a custom configuration file path using the -c/--config flag
instead of always using the default ~/.config/tenere/config.toml path.

Changes:
* Add -c/--config CLI flag accepting a file path
* Modify Config::load() to handle custom config paths

Example usage:
```bash
tenere -c ~/path/to/custom/config.toml
```