### PR TITLE
Automatically load the last saved chat into history

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Vim keybinding (most common ops)
 - Copy text from/to clipboard (works only on the prompt)
 - Multiple backends
+- Automatically load the last saved chat into history
 
 <br>
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,3 +1,5 @@
+use core::str;
+
 use tokio::sync::mpsc::UnboundedSender;
 
 use ratatui::{
@@ -79,6 +81,24 @@ impl History<'_> {
             None => 0,
         };
         self.state.select(Some(i));
+    }
+
+    /// Add to history the archive file if exists
+    pub fn load(&mut self, archive_file_name: &str, sender: UnboundedSender<Event>) {
+        if let Ok(text) = std::fs::read_to_string(archive_file_name) {
+            // push full conversation in preview
+            self.preview.text.push(Text::from(text.clone()));
+            // get first line of the conversation
+            let first_line: String = text.lines().next().unwrap_or("").to_string();
+            self.text.push(vec![first_line]);
+
+            let notif = Notification::new(
+                format!("Chat loaded in history from `{}` file", archive_file_name),
+                NotificationLevel::Info,
+            );
+
+            sender.send(Event::Notification(notif)).unwrap();
+        }
     }
 
     pub fn save(&mut self, archive_file_name: &str, sender: UnboundedSender<Event>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,12 @@ async fn main() -> AppResult<()> {
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 
+    // load potential history data from archive file
+    app.history.load(
+        app.config.archive_file_name.as_str(),
+        tui.events.sender.clone(),
+    );
+
     while app.running {
         tui.draw(&mut app)?;
         match tui.events.next().await? {


### PR DESCRIPTION
Automatically load the last saved chat into history when the application is starting.

If the archive file no exists, it will load nothing