### PR TITLE
Make history persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,12 @@ tenere -c ~/path/to/custom/config.toml
 
 Here are the available general settings:
 
-- `archive_file_name`: the file name where the chat will be saved. By default it is set to `tenere.archive`
 - `llm`: the llm model name. Possible values are:
   - `chatgpt`
   - `llamacpp`
   - `ollama`
 
 ```toml
-archive_file_name = "tenere.archive"
 llm  = "chatgpt"
 ```
 
@@ -107,7 +105,6 @@ Here is an example with the default key bindings
 show_help = '?'
 show_history = 'h'
 new_chat = 'n'
-save_chat = 's'
 ```
 
 ℹ️ Note
@@ -186,9 +183,7 @@ More infos about ollama api [here](https://github.com/ollama/ollama/blob/main/do
 
 These are the default key bindings regardless of the focused block.
 
-`ctrl + n`: Start a new chat and save the previous one in history.
-
-`ctrl + s`: Save the current chat or chat history (history pop-up should be visible first) to `tenere.archive` file in the current directory.
+`ctrl + n`: Start a new chat and save the previous one in history and save it to `tenere.archive-i` file in `data directory`.
 
 `Tab`: Switch the focus.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,6 @@ use std::path::PathBuf;
 
 #[derive(Deserialize, Debug)]
 pub struct Config {
-    #[serde(default = "default_archive_file_name")]
-    pub archive_file_name: String,
-
     #[serde(default)]
     pub key_bindings: KeyBindings,
 
@@ -22,10 +19,6 @@ pub struct Config {
     pub llamacpp: Option<LLamacppConfig>,
 
     pub ollama: Option<OllamaConfig>,
-}
-
-pub fn default_archive_file_name() -> String {
-    String::from("tenere.archive")
 }
 
 pub fn default_llm_backend() -> LLMBackend {
@@ -91,9 +84,6 @@ pub struct KeyBindings {
     #[serde(default = "KeyBindings::default_new_chat")]
     pub new_chat: char,
 
-    #[serde(default = "KeyBindings::default_save_chat")]
-    pub save_chat: char,
-
     #[serde(default = "KeyBindings::default_stop_stream")]
     pub stop_stream: char,
 }
@@ -104,7 +94,6 @@ impl Default for KeyBindings {
             show_help: '?',
             show_history: 'h',
             new_chat: 'n',
-            save_chat: 's',
             stop_stream: 't',
         }
     }
@@ -121,10 +110,6 @@ impl KeyBindings {
 
     fn default_new_chat() -> char {
         'n'
-    }
-
-    fn default_save_chat() -> char {
-        's'
     }
 
     fn default_stop_stream() -> char {

--- a/src/help.rs
+++ b/src/help.rs
@@ -24,10 +24,6 @@ impl Default for Help {
                     Cell::from("ctrl + n").bold().yellow(),
                     "Start new chat and save the previous one to the history",
                 ),
-                (
-                    Cell::from("ctrl + s").bold().yellow(),
-                    "Save the chat to file in the current directory",
-                ),
                 (Cell::from("ctrl + h").bold().yellow(), "Show history"),
                 (
                     Cell::from("ctrl + t").bold().yellow(),

--- a/src/history.rs
+++ b/src/history.rs
@@ -110,13 +110,7 @@ impl History<'_> {
                 }
             }
 
-            let notif = Notification::new(
-                format!(
-                    "Chat loaded in history from `{:?}` files",
-                    directory_path.display()
-                ),
-                NotificationLevel::Info,
-            );
+            let notif = Notification::new("History loaded".to_string(), NotificationLevel::Info);
 
             sender.send(Event::Notification(notif)).unwrap();
         }
@@ -142,10 +136,8 @@ impl History<'_> {
         if !self.text.is_empty() {
             match std::fs::write(file_path.clone(), self.text[chat_index_in_history].join("")) {
                 Ok(_) => {
-                    let notif = Notification::new(
-                        format!("Chat saved to `{}` file", file_path.display()),
-                        NotificationLevel::Info,
-                    );
+                    let notif =
+                        Notification::new("Chat saved".to_string(), NotificationLevel::Info);
 
                     sender.send(Event::Notification(notif)).unwrap();
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,11 +48,12 @@ async fn main() -> AppResult<()> {
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
 
-    // load potential history data from archive file
-    app.history.load(
-        app.config.archive_file_name.as_str(),
-        tui.events.sender.clone(),
-    );
+    // create data directory if not exists
+    app.history
+        .check_data_directory_exists(tui.events.sender.clone());
+
+    // load potential history data from archive files
+    app.history.load_history(tui.events.sender.clone());
 
     while app.running {
         tui.draw(&mut app)?;


### PR DESCRIPTION
After review of the pull request #39, add feature of the issue #33 

Changes:
- Load chats in the data directory to history at the start of the application
- When a new chat is created, save in a file
- Remove default archive file
- Remove Save history feature (CTRL-S)