### PR TITLE
docs: add NixOS installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ You can download the pre-built binaries from the [release page](https://github.c
 cargo install tenere
 ```
 
+### ❄️ NixOS / Nix
+
+Tenere is available in nixpkgs and can be installed via configuration.nix:
+
+```nix
+environment.systemPackages = with pkgs; [
+  tenere
+];
+```
+For non-NixOS systems, install directly with:
+```nix
+nix-env -iA nixpkgs.tenere
+```
+
 ### ⚒️ Build from source
 
 To build from the source, you need [Rust](https://www.rust-lang.org/) compiler and


### PR DESCRIPTION
Add NixOS package installation section under a new "Package Managers" category in the installation instructions. This reflects tenere's recent addition to nixpkgs (NixOS/nixpkgs/pull/363556)

Resolves pythops/tenere#43
