### PR TITLE
Fix: #51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",
+  "stream"
 ] }
 ratatui = { version = "0.29", features = ["all-widgets"] }
 regex = "1"
@@ -32,6 +33,7 @@ tokio = { version = "1", features = ["full"] }
 toml = { version = "0.8" }
 tui-textarea = "0.7"
 unicode-width = "0.2"
+bytes = "1.0"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
Fix Stream Handling (https://github.com/pythops/tenere/issues/51): 

- Uses Bytes instead of raw byte slices
- Proper line splitting with buffer management
- More robust line processing with boundary checks

## Modifcation

1. `Cargo.toml`: 
    - bytes
    - reqwest::stream
 2. Fix chatgpt only.

Now one could use chatgpt approach and specify the base_url to use LM Studio.
